### PR TITLE
Add css font-display property

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The plug-in will take supported formats(.woff & .woff2 by default), convert them
     font-style: normal;
     font-stretch: normal;
     font-weight: 400;
+    font-display: auto;
     src: local("icons"), url("data:application/font-woff;base64,...") format("woff"),
       url("data:application/font-woff2;base64,...") format("woff2");
   }
@@ -87,6 +88,7 @@ gulp.task('fonts', function() {
   style: 'normal',
   stretch: 'normal',
   weight: 400,
+  display: 'auto',
   formats: ['woff', 'woff2'] // also supported: 'ttf', 'eot', 'otf', 'svg'
 }
 ```

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var cssFormats = {
 
 module.exports = function(custom) {
   var fonts = [],
-    options = { name: 'font', style: 'normal', weight: 400, formats: ['woff', 'woff2'], stretch: 'normal' },
+    options = { name: 'font', style: 'normal', weight: 400, formats: ['woff', 'woff2'], stretch: 'normal', display : 'auto' },
     output = null;
 
   for(var attr in custom) { options[attr] = custom[attr] }
@@ -73,11 +73,12 @@ module.exports = function(custom) {
       acc[font.cssFormat ? 1 : 0].push(font);
       return acc;
     }, [[], []]);
-    var content = '@font-face { ' +
+    var content = '@font-face { ' +  
       'font-family: "' + options.name + '"; ' +
       'font-style: ' + options.style + '; ' +
       'font-stretch: ' + options.stretch + '; ' +
       'font-weight: ' + options.weight + '; ' +
+      'font-display: ' + options.display + '; ' + 
       fontGroups[0].map(function(f) { return 'src: ' + f.compile() + '; '}).join('') +
       'src: local("' + options.name + '"), ' + fontGroups[1].map(function(f) { return f.compile() }).join(', ') + '; ' +
     '}';

--- a/test/test.js
+++ b/test/test.js
@@ -20,7 +20,7 @@ describe('gulp-inline-fonts', function() {
         .pipe(plugin())
         .pipe(assert.length(1))
         .pipe(is_equal('font', [
-          '@font-face { font-family: "font"; font-style: normal; font-stretch: normal; font-weight: 400; ',
+          '@font-face { font-family: "font"; font-style: normal; font-stretch: normal; font-weight: 400; font-display: auto; ',
           'src: local("font"), url("data:font/woff;base64,") format("woff"), ',
             'url("data:font/woff2;base64,") format("woff2"); }'
         ]))
@@ -29,10 +29,10 @@ describe('gulp-inline-fonts', function() {
 
     it('allows to specify a custom options', function(done) {
       gulp.src(fixtures('simple/myfont.*'))
-        .pipe(plugin({ formats: ['ttf', 'otf'], name: 'myfont', weight: 200, style: 'italic' }))
+        .pipe(plugin({ formats: ['ttf', 'otf'], name: 'myfont', weight: 200, style: 'italic', display: 'fallback' }))
         .pipe(assert.length(1))
         .pipe(is_equal('myfont', [
-          '@font-face { font-family: "myfont"; font-style: italic; font-stretch: normal; font-weight: 200; ',
+          '@font-face { font-family: "myfont"; font-style: italic; font-stretch: normal; font-weight: 200; font-display: fallback; ',
           'src: url("data:font/otf;base64,"); ',
           'src: local("myfont"), url("data:font/ttf;base64,") format("truetype"); }'
         ]))


### PR DESCRIPTION
Add css "font-display" property, as Chrome Lighthouse Audit is now, highlighting
https://developers.google.com/web/updates/2016/02/font-display.
Coded in same style; hence param value is not validated.